### PR TITLE
Add project pages and update portfolio content

### DIFF
--- a/formula-student.html
+++ b/formula-student.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Formula Student TUC - Predictive Engine Safety Modeling</title>
+<style>
+  body {background:#0B1426;color:#E3F2FD;font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;line-height:1.6;padding:20px;}
+  h1 {color:#00E5FF;margin-bottom:20px;}
+  a {color:#1E88E5;}
+  .panel {background:#152238;padding:20px;border:1px solid #1E88E5;border-radius:6px;}
+</style>
+</head>
+<body>
+<div class="panel">
+<h1>Formula Student TUC - Predictive Engine Safety Modeling</h1>
+<p>Capstone project forecasting critical telemetry signals such as Lambda and RPM using LSTM, ARIMAX, and ETSformer models. Achieved sub-5&nbsp;ms latency deployments on embedded ECUs, inspired by real-world incidents like Hamilton's 2024 Grand Prix retirement.</p>
+<p><a href="MLDS%20(7).pdf">Download report (PDF)</a></p>
+<p><a href="index.html">Back to Home</a></p>
+</div>
+</body>
+</html>

--- a/har-drive.html
+++ b/har-drive.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>HAR-DRive — High-Accuracy Activity Recognition with PCA/LDA</title>
+<style>
+  body {background:#0B1426;color:#E3F2FD;font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;line-height:1.6;padding:20px;}
+  h1 {color:#00E5FF;margin-bottom:20px;}
+  a {color:#1E88E5;}
+  .panel {background:#152238;padding:20px;border:1px solid #1E88E5;border-radius:6px;}
+</style>
+</head>
+<body>
+<div class="panel">
+<h1>HAR-DRive — High-Accuracy Activity Recognition with PCA/LDA</h1>
+<p>Developed a Python/scikit-learn pipeline that pits PCA against LDA on the UCI HAR dataset (10k traces, 561 features). Automated preprocessing, 5-fold cross-validation, and grid search showed that a 5-dimensional LDA with an SVM-RBF cuts features by 98% while scoring macro-F1&nbsp;0.984, a +16 pp gain over the raw baseline.</p>
+<p><a href="report.pdf">Download report (PDF)</a></p>
+<p><a href="index.html">Back to Home</a></p>
+</div>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -153,45 +153,45 @@
     <p>Presenting: Konstantinos Zervakis - AI / Machine Learning Engineer</p>
   </header>
 
-  <section id="summary" class="panel">
+    <section id="summary" class="panel">
     <h2>Personnel File</h2>
-    <p>Analysis complete. Technology enthusiast and future-driven engineer with strong academic background in Machine Learning, Mathematics, and Robotics. Specialized in autonomous systems, reinforcement learning, and predictive modeling. Currently leading AI forecasting startup with multiple real-time AI projects across finance, motorsport, and agriculture.</p>
-  </section>
+    <p>Analysis complete. Technology enthusiast and future-driven engineer with a strong academic background in Machine Learning, Mathematics, and Robotics. Passionate about autonomous systems, reinforcement learning, and predictive modeling. Currently leading an AI forecasting startup and contributing to real-time AI projects across finance, motorsport, and agriculture.</p>
+    </section>
 
   <section id="education" class="panel">
     <h2>Academic Records</h2>
     <div class="stats">
       <div class="stat">
         <h3>MSc, Machine Learning &amp; Data Science</h3>
-        <p>Technical University of Crete (Sep 2024)<br>
-        Honours courses: Practical Data Science, Optimisation, Databases, Probabilities &amp; ML</p>
+        <p>Technical University of Crete (Sep 2025)<br>
+        Honours courses: Practical Data Science, Optimisation, Data bases, Probabilities &amp; ML</p>
       </div>
       <div class="stat">
         <h3>BSc, Mathematics &amp; Applied Mathematics</h3>
         <p>University of Crete (2024)<br>
-        Advanced Calculus, Linear Algebra, Probability Theory, Algorithms. Graduated with 241 ECTS.</p>
+        Advanced Calculus, Linear Algebra, Probability Theory, Algorithms, Applied &amp; Parametric Statistics, Global Economics.<br>
+        Graduated with 241 ECTS.</p>
       </div>
     </div>
   </section>
 
   <section id="projects" class="panel">
-    <h2>Active Operations</h2>
+    <h2>Projects</h2>
     <div class="stats">
       <div class="stat">
-        <h3>AI Financial Forecasting Startup</h3>
-        <p>Founder &amp; Technical Lead<br>
-        Hybrid forecasting pipelines (ARIMAX, XGBoost, LSTM, Transformer).<br>
-        Real-time financial prediction for algorithmic trading. (Jan 2025 - Present)</p>
+        <h3>Predictive Maintenance ML System – Hydraulic Equipment</h3>
+        <p>Modular pipeline for UCI 447 sensor data with engineered features, interpretable models, and real-time FastAPI service.<br>
+        <a href="predictive-maintenance.html">Project Link</a></p>
       </div>
       <div class="stat">
-        <h3>Aerial Intelligence System</h3>
-        <p>YOLOv8-based detection for UAV imagery. REST API for drone-ground communication.<br>
-        Dockerized models on Jetson devices. (Jun 2025 - Present)</p>
+        <h3>HAR-DRive — High-Accuracy Activity Recognition with PCA/LDA</h3>
+        <p>Automated PCA vs LDA pipeline on UCI HAR; 5-D LDA + SVM-RBF achieves macro-F1 0.984 with 98% feature reduction.<br>
+        <a href="har-drive.html">Project Link</a> | <a href="report.pdf">Report (PDF)</a></p>
       </div>
       <div class="stat">
-        <h3>Humanoid Robotics</h3>
-        <p>Vision-Based Reinforcement Learning on MuJoCo humanoids via PPO/CNN.<br>
-        Real-time locomotion control and curriculum learning. (May 2025 - Present)</p>
+        <h3>LightningText — Ultra-Lean, Real-Time Text Analytics on Apache Spark</h3>
+        <p>Spark pipeline with sketching and compression to analyze 14M BookCorpus paragraphs in real time using only 20&nbsp;KB RAM.<br>
+        <a href="lightningtext.html">Project Link</a> | <a href="BD.pdf">Report (PDF)</a></p>
       </div>
     </div>
   </section>
@@ -200,14 +200,9 @@
     <h2>Mission Archive</h2>
     <div class="stats">
       <div class="stat">
-        <h3>Formula Student TUC - Predictive Engine Safety</h3>
-        <p>Forecasted critical telemetry signals using LSTM, ARIMAX, ETSformer.<br>
-        &lt;5ms latency deployment on embedded ECUs. Inspired by real-world F1 failures. (Apr 2025)</p>
-      </div>
-      <div class="stat">
-        <h3>IoT Environmental Monitoring Platform</h3>
-        <p>End-to-end sensor-to-cloud pipeline (ESP32 + MQTT). IsolationForest anomaly detection + LSTM forecasting.<br>
-        Real-time dashboards via Grafana and WebSocket streams. (Mar 2025)</p>
+        <h3>Formula Student TUC - Predictive Engine Safety Modeling</h3>
+        <p>Forecasted telemetry signals (Lambda, RPM) via LSTM, ARIMAX, ETSformer with &lt;5ms latency on embedded ECUs.<br>
+        <a href="formula-student.html">Project Link</a> | <a href="MLDS%20(7).pdf">Report (PDF)</a></p>
       </div>
     </div>
   </section>
@@ -217,21 +212,15 @@
     <div class="stats">
       <div class="stat">
         <h3>Programming Languages</h3>
-        <p>Python (90% proficiency)<br>
-        C++ (70% proficiency)<br>
-        SQL, MATLAB, JavaScript (60% proficiency)</p>
+        <p>Python, C++, SQL (PostgreSQL), MATLAB</p>
       </div>
       <div class="stat">
-        <h3>AI/ML Frameworks</h3>
-        <p>PyTorch, TensorFlow, Scikit-learn<br>
-        YOLOv8, FastAPI<br>
-        MuJoCo, OpenAI Gym, PPO, CNNs</p>
+        <h3>ML &amp; Forecasting</h3>
+        <p>PyTorch, TensorFlow, scikit-learn, XGBoost, ARIMAX/ARIMA, LSTM, Transformers (ETSformer), SHAP</p>
       </div>
       <div class="stat">
-        <h3>Data &amp; Deployment</h3>
-        <p>Pandas, Numpy, Matplotlib, Seaborn<br>
-        Docker, GitHub Actions, Heroku, CI/CD<br>
-        REST APIs, Jetson, CAN Bus integration</p>
+        <h3>MLOps &amp; Deployment</h3>
+        <p>FastAPI, Docker, Kubernetes, MLflow, Airflow, GitHub Actions, Prometheus, Grafana, Evidently</p>
       </div>
     </div>
   </section>
@@ -262,8 +251,8 @@
     <p>ESTABLISHING SECURE CONNECTION</p>
     <p>Contact: <a href="mailto:zervakisai@gmail.com">zervakisai@gmail.com</a></p>
     <p>Phone: <a href="tel:+306940696921">+30 6940 696921</a></p>
-    <p>GitHub: <a href="#">Profile Link</a></p>
-    <p>LinkedIn: <a href="#">Profile Link</a></p>
+    <p>GitHub: <a href="https://github.com/zervakisai">zervakisai</a></p>
+    <p>LinkedIn: <a href="https://www.linkedin.com/in/-zervakisai-">Profile</a></p>
     <p>END TRANSMISSION</p>
   </section>
 

--- a/lightningtext.html
+++ b/lightningtext.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>LightningText — Ultra-Lean, Real-Time Text Analytics on Apache Spark</title>
+<style>
+  body {background:#0B1426;color:#E3F2FD;font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;line-height:1.6;padding:20px;}
+  h1 {color:#00E5FF;margin-bottom:20px;}
+  a {color:#1E88E5;}
+  .panel {background:#152238;padding:20px;border:1px solid #1E88E5;border-radius:6px;}
+</style>
+</head>
+<body>
+<div class="panel">
+<h1>LightningText — Ultra-Lean, Real-Time Text Analytics on Apache Spark</h1>
+<p>Built and tuned an Apache Spark pipeline that processes 14&nbsp;million BookCorpus paragraphs (3.4&nbsp;GB) in real time. Combined reservoir sampling, Count-Min Sketch, Flajolet–Martin, and wavelet compression to detect heavy hitters and estimate vocabulary with under 2% error using only 20&nbsp;KB of RAM, delivering 8× leaner storage and minute-level insight.</p>
+<p><a href="BD.pdf">Download report (PDF)</a></p>
+<p><a href="index.html">Back to Home</a></p>
+</div>
+</body>
+</html>

--- a/predictive-maintenance.html
+++ b/predictive-maintenance.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Predictive Maintenance ML System – Hydraulic Equipment</title>
+<style>
+  body {background:#0B1426;color:#E3F2FD;font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;line-height:1.6;padding:20px;}
+  h1 {color:#00E5FF;margin-bottom:20px;}
+  a {color:#1E88E5;}
+  .panel {background:#152238;padding:20px;border:1px solid #1E88E5;border-radius:6px;}
+</style>
+</head>
+<body>
+<div class="panel">
+<h1>Predictive Maintenance ML System – Hydraulic Equipment</h1>
+<p>Built a modular machine learning pipeline for the UCI 447 hydraulic systems dataset. Automated project scaffolding, engineered time-series features, trained interpretable models (XGBoost, Random Forest), and deployed a real-time FastAPI service with alerting logic. Included SHAP-based explainability, MLflow tracking, and monitoring with Prometheus, Grafana, and Evidently.</p>
+<p><a href="index.html">Back to Home</a></p>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Refresh profile summary and education details
- Highlight new ML projects with links to standalone pages
- Streamline skills and update contact links
- Link downloadable report PDFs for HAR-DRive, LightningText, and Formula Student using correct filenames
- Expose direct PDF report links from the main index page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6892100d1a288332b6df578609f01084