### PR TITLE
Add code links for ML notebooks and hydraulic maintenance project

### DIFF
--- a/formula-student.html
+++ b/formula-student.html
@@ -16,6 +16,7 @@
 <h1>Formula Student TUC - Predictive Engine Safety Modeling</h1>
 <p>Capstone project forecasting critical telemetry signals such as Lambda and RPM using LSTM, ARIMAX, and ETSformer models. Achieved sub-5&nbsp;ms latency deployments on embedded ECUs, inspired by real-world incidents like Hamilton's 2024 Grand Prix retirement.</p>
 <p><a href="formula-student-report.pdf">Download report (PDF)</a></p>
+<p><a href="MLDS (2).ipynb">Download notebook (IPYNB)</a></p>
 <p><a href="index.html">Back to Home</a></p>
 </div>
 </body>

--- a/index.html
+++ b/index.html
@@ -61,7 +61,8 @@
             Predictive Maintenance ML System – Hydraulic Equipment. Modular
             pipeline for UCI 447 sensor data with engineered features,
             interpretable models, and real-time FastAPI service.
-            <a href="predictive-maintenance.html">Project</a>
+            <a href="predictive-maintenance.html">Project</a> |
+            <a href="https://github.com/zervakisai/hydraulic-maintenance" target="_blank" rel="noopener noreferrer">Code</a>
           </li>
           <li>
             HAR-DRive — High-Accuracy Activity Recognition with PCA/LDA.
@@ -75,14 +76,16 @@
             Spark. Spark pipeline with sketching and compression to analyze 14M
             BookCorpus paragraphs in real time using only 20&nbsp;KB RAM.
             <a href="lightningtext.html">Project</a> |
-            <a href="BD.pdf">Report</a>
+            <a href="BD.pdf">Report</a> |
+            <a href="BD.ipynb">Code</a>
           </li>
           <li>
             Formula Student TUC - Predictive Engine Safety Modeling. Forecasted
             telemetry signals (Lambda, RPM) via LSTM, ARIMAX, ETSformer with
             &lt;5ms latency on embedded ECUs.
             <a href="formula-student.html">Project</a> |
-            <a href="MLDS (7).pdf">Report</a>
+            <a href="MLDS (7).pdf">Report</a> |
+            <a href="MLDS (2).ipynb">Code</a>
           </li>
         </ul>
       </section>

--- a/lightningtext.html
+++ b/lightningtext.html
@@ -16,6 +16,7 @@
 <h1>LightningText — Ultra-Lean, Real-Time Text Analytics on Apache Spark</h1>
 <p>Built and tuned an Apache Spark pipeline that processes 14&nbsp;million BookCorpus paragraphs (3.4&nbsp;GB) in real time. Combined reservoir sampling, Count-Min Sketch, Flajolet–Martin, and wavelet compression to detect heavy hitters and estimate vocabulary with under 2% error using only 20&nbsp;KB of RAM, delivering 8× leaner storage and minute-level insight.</p>
 <p><a href="lightningtext-report.pdf">Download report (PDF)</a></p>
+<p><a href="BD.ipynb">Download notebook (IPYNB)</a></p>
 <p><a href="index.html">Back to Home</a></p>
 </div>
 </body>

--- a/predictive-maintenance.html
+++ b/predictive-maintenance.html
@@ -15,6 +15,7 @@
 <div class="panel">
 <h1>Predictive Maintenance ML System – Hydraulic Equipment</h1>
 <p>Built a modular machine learning pipeline for the UCI 447 hydraulic systems dataset. Automated project scaffolding, engineered time-series features, trained interpretable models (XGBoost, Random Forest), and deployed a real-time FastAPI service with alerting logic. Included SHAP-based explainability, MLflow tracking, and monitoring with Prometheus, Grafana, and Evidently.</p>
+<p><a href="https://github.com/zervakisai/hydraulic-maintenance" target="_blank" rel="noopener noreferrer">Code on GitHub</a></p>
 <p><a href="index.html">Back to Home</a></p>
 </div>
 </body>


### PR DESCRIPTION
## Summary
- Link hydraulic-maintenance GitHub repo from predictive maintenance project
- Add notebook download links for LightningText and Formula Student projects
- Surface new code links on home page project list

## Testing
- `npx prettier@3 --check index.html lightningtext.html formula-student.html predictive-maintenance.html` *(fails: 403 Forbidden)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1e6d5307883329819aabcff0f9d1c